### PR TITLE
Task-51718 : In automatic administration page, some string are not i18n

### DIFF
--- a/webapps/src/main/resources/locale/portlet/automaticTranslation/automaticTranslationAdministration_en.properties
+++ b/webapps/src/main/resources/locale/portlet/automaticTranslation/automaticTranslationAdministration_en.properties
@@ -7,7 +7,7 @@ automatic.translation.administration.changeConnector.error=Translation Connector
 automatic.translation.administration.changeApiKey.confirm=Key saved successfully
 automatic.translation.administration.changeApiKey.emptykey.confirm=The key field is empty please check it before you continue
 automatic.translation.administration.changeApiKey.error=The entered key can not be saved
-
 automatic.translation.administration.enterYourKey=Enter your API key :
 automatic.translation.administration.apiKeyPlaceHolder=API Key
 automatic.translation.apikey.button.save=Save
+automatic.translation.analytics.title.charTranslated=Characters translated

--- a/webapps/src/main/resources/locale/portlet/automaticTranslation/automaticTranslationAdministration_fr.properties
+++ b/webapps/src/main/resources/locale/portlet/automaticTranslation/automaticTranslationAdministration_fr.properties
@@ -7,7 +7,7 @@ automatic.translation.administration.changeConnector.error=Le changement de conn
 automatic.translation.administration.changeApiKey.confirm=La cl\u00E9 d'API a \u00E9t\u00E9 enregistr\u00E9e avec succ\u00E8s.
 automatic.translation.administration.changeApiKey.emptykey.confirm=La cl\u00E9 d'API est vide. Merci de v\u00E9rifier avant de continuer.
 automatic.translation.administration.changeApiKey.error=La cl\u00E9 choisie n'a pas pu \u00EAtre sauvegard\u00E9e
-
 automatic.translation.administration.enterYourKey=Saisissez votre cl\u00E9 d'API :
 automatic.translation.administration.apiKeyPlaceHolder=Cl\u00E9 d'API
 automatic.translation.apikey.button.save=Enregistrer
+automatic.translation.analytics.title.charTranslated=Nombre de caract\u00E8res traduits

--- a/webapps/src/main/webapp/WEB-INF/conf/automatic-translation/portal-configuration.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/automatic-translation/portal-configuration.xml
@@ -26,7 +26,7 @@
                             <boolean>${exo.automatic-translation.portalConfig.metadata.override:true}</boolean>
                         </field>
                         <field name="importMode">
-                            <string>${exo.automatic-translation.portalConfig.metadata.importmode:merge}</string>
+                            <string>${exo.automatic-translation.portalConfig.metadata.importmode:overwrite}</string>
                         </field>
                         <field name="templateLocation">
                             <string>war:/conf/automatic-translation/portal</string>

--- a/webapps/src/main/webapp/WEB-INF/conf/automatic-translation/portal/group/platform/administrators/pages.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/automatic-translation/portal/group/platform/administrators/pages.xml
@@ -108,7 +108,7 @@
                   "multipleChartsField": null,
                   "limit": 0,
                   "timeZone": null,
-                  "title": "Characters translated"
+                  "title": "automatic.translation.analytics.title.charTranslated"
                   }
                 </value>
               </preference>


### PR DESCRIPTION
- Graph title
- Samples drawer title
- Header of json popup

This fix add the correct i18n string, and it update the graph configuration on automatic translation administration page.