### PR TITLE
fix: issue in google translator connector with text contains single quote char - EXO-66886

### DIFF
--- a/services/impl/src/main/java/org/exoplatform/automatic/translation/impl/connectors/DeepLTranslateConnector.java
+++ b/services/impl/src/main/java/org/exoplatform/automatic/translation/impl/connectors/DeepLTranslateConnector.java
@@ -37,7 +37,6 @@ public class DeepLTranslateConnector extends AutomaticTranslationComponentPlugin
     super(settingService);
     textTranslationOptions = new TextTranslationOptions();
     textTranslationOptions.setTagHandling("html");
-    textTranslationOptions.setPreserveFormatting(true);
     textTranslationOptions.setSentenceSplittingMode(SentenceSplittingMode.All);
   }
 

--- a/services/impl/src/main/java/org/exoplatform/automatic/translation/impl/connectors/GoogleTranslateConnector.java
+++ b/services/impl/src/main/java/org/exoplatform/automatic/translation/impl/connectors/GoogleTranslateConnector.java
@@ -47,7 +47,7 @@ public class GoogleTranslateConnector extends AutomaticTranslationComponentPlugi
 
   private static final String KEY_PARAM                = "key";
 
-  private static final String DATA_PATTERN             = "{'q': '{message}', 'target': '{targetLocale}'}";
+  private static final String DATA_PATTERN             = "{\"q\": \"{message}\", \"target\": \"{targetLocale}\"}";
 
   private static final int    DEFAULT_POOL_CONNECTION  = 100;
 

--- a/services/impl/src/test/java/org/exoplatform/automatic/translation/impl/connectors/DeepLTranslateConnectorTest.java
+++ b/services/impl/src/test/java/org/exoplatform/automatic/translation/impl/connectors/DeepLTranslateConnectorTest.java
@@ -52,7 +52,6 @@ public class DeepLTranslateConnectorTest {
     // Need real auth-key to have a real result
     TextTranslationOptions textTranslationOptions = new TextTranslationOptions();
     textTranslationOptions.setTagHandling("html");
-    textTranslationOptions.setPreserveFormatting(true);
     textTranslationOptions.setSentenceSplittingMode(SentenceSplittingMode.All);
     TextResult textResult = new TextResult("<h1>Hello</h1>", "fr");
     Field textTranslationOptionsField = deepLTranslateConnector.getClass().getDeclaredField("textTranslationOptions");


### PR DESCRIPTION
…
Prior to this change, when attempting to translate a text with a simple quote char with google translator, the connector fails due to existing quote char in the text due to the use of signle quotes in the request param. This prevents this situation by using escaped double quotes in the qurey param.