### PR TITLE
fix: fix set auto translation selected when notes has no content  - EXO-67680

### DIFF
--- a/webapps/src/main/webapp/javascript/automatic-translation/components/NoteAutomaticTranslation.vue
+++ b/webapps/src/main/webapp/javascript/automatic-translation/components/NoteAutomaticTranslation.vue
@@ -95,6 +95,7 @@ export default {
             }).catch(() => this.isAutoTranslating = false);
           } else {
             this.hasContent = false;
+            this.setAutoTranslationSelected();
             this.isAutoTranslating = false;
           }
         }).catch(() => this.isAutoTranslating = false);


### PR DESCRIPTION
Prior to this change, when notes has no content or only navigation, when we execute the automatic translation and only the title is translated then the automatic translation option is not set as selected. 
This PR makes sure to update the translation selection when only title translated