### PR TITLE
fix: Fix translating note when switching between notes from notes tree or note home navigation - EXO-79268

### DIFF
--- a/webapps/src/main/webapp/vue-apps/automatic-translation-extensions/notes-extension/components/NoteAutomaticTranslation.vue
+++ b/webapps/src/main/webapp/vue-apps/automatic-translation-extensions/notes-extension/components/NoteAutomaticTranslation.vue
@@ -41,6 +41,7 @@ export default {
       isResetAutoTranslating: false,
       autoTranslation: { value: 'autoTranslation', text: this.$t('notes.automatic.translation.label') },
       previouslyTranslatedVersion: null,
+      previouslyTranslatedNoteId: null,
       autoTranslatedContent: null,
       autoTranslatedTitle: null,
       autoTranslatedSummary: null,
@@ -74,12 +75,13 @@ export default {
   },
   methods: {
     autoTranslate() {
-      if (this.autoTranslatedContent) {
+      if (this.note.id === this.previouslyTranslatedNoteId) {
         this.setAutoTranslationSelected();
       } else {
         this.isAutoTranslating = true;
         this.$automaticTranslationExtensionsService.fetchAutoTranslation(this.note.title).then(translated => {
           this.handleTranslatedTitle(translated.translation);
+          this.previouslyTranslatedNoteId = this.note.id;
           const summary = this.note?.properties?.summary;
           if (summary) {
             this.$automaticTranslationExtensionsService.fetchAutoTranslation(summary).then(translated => {


### PR DESCRIPTION
Prior to this change, when switching between notes from notes tree or notes home navigation, the auto translation when already done is not re-executed and the last auto-translated note is displayed.
After this commit, we ensure to auto translate the note whenever the note id is not same to the last auto translated note id.