### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/services/impl/src/main/java/org/exoplatform/automatic/translation/listener/analytics/AutomaticTranslationListener.java
+++ b/services/impl/src/main/java/org/exoplatform/automatic/translation/listener/analytics/AutomaticTranslationListener.java
@@ -22,7 +22,7 @@ import org.exoplatform.automatic.translation.api.dto.AutomaticTranslationEvent;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 
-public class AutomaticTranslationListener extends Listener<String,AutomaticTranslationEvent> {
+public class AutomaticTranslationListener extends Listener<String, AutomaticTranslationEvent> {
 
   @Override
   public void onEvent(Event<String, AutomaticTranslationEvent> event) throws Exception {
@@ -33,10 +33,10 @@ public class AutomaticTranslationListener extends Listener<String,AutomaticTrans
     statisticData.setOperation("translate");
     statisticData.setUserId(AnalyticsUtils.getCurrentUserIdentityId());
     statisticData.setSpaceId(data.getSpaceId());
-    statisticData.addParameter("messageLength", data.getMessageLength());
-    statisticData.addParameter("targetLanguage", data.getTargetLanguage());
-    statisticData.addParameter("contentType", data.getContentType());
-    statisticData.addParameter("connector", data.getConnectorName());
+    statisticData.addLong("messageLength", data.getMessageLength());
+    statisticData.addKeyword("targetLanguage", data.getTargetLanguage());
+    statisticData.addKeyword("contentType", data.getContentType());
+    statisticData.addKeyword("connector", data.getConnectorName());
     AnalyticsUtils.addStatisticData(statisticData);
   }
 }


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.