### PR TITLE
fix: XML configuration for external component plugins

### DIFF
--- a/services/impl/src/main/resources/conf/portal/configuration.xml
+++ b/services/impl/src/main/resources/conf/portal/configuration.xml
@@ -40,9 +40,9 @@
     </component-plugin>
   </external-component-plugins>
 
-  <external-component-plugins profiles="analytics">
+  <external-component-plugins>
     <target-component>org.exoplatform.services.listener.ListenerService</target-component>
-    <component-plugin>
+    <component-plugin profiles="analytics">
       <name>exo.automatic-translation.event.translate</name>
       <set-method>addListener</set-method>
       <type>org.exoplatform.automatic.translation.listener.analytics.AutomaticTranslationListener</type>


### PR DESCRIPTION
Prior to this change, when starting the server, an error is thrown:
```
ERROR | In document jar:/srv/exo/lib/automatic-translation-services-impl.jar!/conf/portal/configuration.xml  at (43,52) :cvc-complex-type.3.2.2: Attribute 'profiles' is not allowed to appear in element 'external-component-plugins'.
```

This change moves the `profiles` attribute into `component-plugin` instead.