### PR TITLE
fix: improve error handling in autoTranslate of note editor extension  with precise message and value restoration - EXO-87087

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -45,4 +45,14 @@ files: [
     "escape_special_characters": 0,
     "escape_quotes" : 0,
   },
+  {
+    "source": "/webapps/src/main/resources/locale/portlet/automaticTranslation/NotesEditorExtension_en.properties",
+
+    "translation": "%original_path%/%file_name%!_%locale_with_underscore%.%file_extension%",
+    "translation_replace": { YML_CROWDIN_LANGUAGES_ARG },
+    "dest": "add__ons/automatic__translation/NotesEditorExtension.properties",
+    "update_option": "update_as_unapproved",
+    "escape_special_characters": 0,
+    "escape_quotes": 0,
+  },
 ]

--- a/webapps/src/main/resources/locale/portlet/automaticTranslation/NotesEditorExtension_en.properties
+++ b/webapps/src/main/resources/locale/portlet/automaticTranslation/NotesEditorExtension_en.properties
@@ -1,0 +1,4 @@
+NotesEditor.translate.title.error=Error while translating content title, {0}
+NotesEditor.translate.summary.error=Error while translating content summary, {0}
+NotesEditor.translate.content.error=Error while translating content body, {0}
+NotesEditor.translate.error=Error while translating content, {0}

--- a/webapps/src/main/resources/locale/portlet/automaticTranslation/NotesEditorExtension_fr.properties
+++ b/webapps/src/main/resources/locale/portlet/automaticTranslation/NotesEditorExtension_fr.properties
@@ -1,0 +1,4 @@
+NotesEditor.translate.title.error=Erreur lors de la traduction du titre du contenu, {0}
+NotesEditor.translate.summary.error=Erreur lors de la traduction du r\u00e9sum\u00e9 du contenu, {0}
+NotesEditor.translate.content.error=Erreur lors de la traduction du corps du contenu, {0}
+NotesEditor.translate.error=Erreur lors de la traduction du contenu, {0}

--- a/webapps/src/main/webapp/vue-apps/automatic-translation-extensions/notes-editor-extension/components/NoteEditorAutomaticTranslation.vue
+++ b/webapps/src/main/webapp/vue-apps/automatic-translation-extensions/notes-editor-extension/components/NoteEditorAutomaticTranslation.vue
@@ -26,21 +26,47 @@ export default {
 
   methods: {
     autoTranslate(noteContent) {
+      const promises = [
+        {
+          promise: this.$automaticTranslationExtensionsService.fetchAutoTranslation(noteContent.title, noteContent.lang)
+            .then(translated => this.updateNoteTitle(translated.translation)),
+          errorKey: 'NotesEditor.translate.title.error',
+          restore: () => this.updateNoteTitle(noteContent.title)
+        },
+        noteContent?.properties?.summary && {
+          promise: this.$automaticTranslationExtensionsService.fetchAutoTranslation(noteContent.properties.summary, noteContent.lang)
+            .then(translated => this.updateNoteSummary(translated.translation)),
+          errorKey: 'NotesEditor.translate.summary.error',
+          restore: () => this.updateNoteSummary(noteContent.properties.summary)
+        },
+        noteContent.content && {
+          promise: this.fetchContentTranslation(noteContent),
+          errorKey: 'NotesEditor.translate.content.error',
+          restore: () => this.updateNoteContent(noteContent.content)
+        }
+      ].filter(Boolean);
+
       document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
-      this.$automaticTranslationExtensionsService.fetchAutoTranslation(noteContent.title, noteContent.lang).then(translated => {
-        this.updateNoteTitle(translated.translation);
-        if (noteContent?.properties?.summary) {
-          document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
-          this.$automaticTranslationExtensionsService.fetchAutoTranslation(noteContent?.properties?.summary, noteContent.lang).then(translated => {
-            this.updateNoteSummary(translated.translation);
-            if (noteContent.content) {
-              this.fetchContentTranslation(noteContent);
-            }
-          }).finally(() => {
-            document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
+      Promise.allSettled(promises.map(t => t.promise)).then(results => {
+        const failedIndices = results
+          .map((result, i) => (result.status === 'rejected' ? i : null))
+          .filter(i => i !== null);
+
+        failedIndices.forEach(i => promises[i].restore());
+
+        if (failedIndices.length > 1) {
+          const errors = failedIndices.map(i => results[i].reason);
+          this.$root.$emit('show-alert', {
+            type: 'error',
+            message: this.$t('NotesEditor.translate.error', {0: errors.map(e => e.message || e).join(', ')})
           });
-        } else if (noteContent.content) {
-          this.fetchContentTranslation(noteContent);
+        } else if (failedIndices.length === 1) {
+          const i = failedIndices[0];
+          const error = results[i].reason;
+          this.$root.$emit('show-alert', {
+            type: 'error',
+            message: this.$t(promises[i].errorKey, {0: [error.message || error]})
+          });
         }
       }).finally(() => {
         document.dispatchEvent(new CustomEvent('hideTopBarLoading'));
@@ -49,7 +75,7 @@ export default {
     fetchContentTranslation(note) {
       const content = this.excludeHtmlSpaceEntities(note.content);
       document.dispatchEvent(new CustomEvent('displayTopBarLoading'));
-      this.$automaticTranslationExtensionsService.fetchAutoTranslation(content, note.lang).then(translated => {
+      return this.$automaticTranslationExtensionsService.fetchAutoTranslation(content, note.lang).then(translated => {
         const translatedContent = this.restoreHtmlSpaceEntities(translated.translation);
         this.updateNoteContent(translatedContent);
       }).finally(() => {

--- a/webapps/src/main/webapp/vue-apps/automatic-translation-extensions/notes-editor-extension/main.js
+++ b/webapps/src/main/webapp/vue-apps/automatic-translation-extensions/notes-editor-extension/main.js
@@ -19,12 +19,17 @@ import './initComponents.js';
 import {initExt} from './extensions.js';
 import * as  automaticTranslationExtensionsService from '../js/AutomaticTranslationExtensionsService.js';
 
+const lang = eXo?.env?.portal?.language || 'en';
+
+const url = `/automaticTranslation/i18n/locale.portlet.automaticTranslation.NotesEditorExtension?lang=${lang}`;
+
 if (!Vue.prototype.$automaticTranslationExtensionsService) {
   window.Object.defineProperty(Vue.prototype, '$automaticTranslationExtensionsService', {
     value: automaticTranslationExtensionsService,
   });
 }
 
-export function init() {
+export async function init() {
+  await exoi18n.loadLanguageAsync(lang, url);
   initExt();
 }


### PR DESCRIPTION
- Run title, summary and content translations in parallel with Promise.allSettled
- Display specific error message when a single field fails, general message when multiple fail
- Restore original field value on translation failure via per-task restore callbacks
- Remove nested promise chain in favor of flat parallel execution